### PR TITLE
added optional prefix and whitelist for pseudo classes to use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 npm-debug.log
+.idea

--- a/test/fixtures/prefix-pseudos.out.css
+++ b/test/fixtures/prefix-pseudos.out.css
@@ -1,0 +1,68 @@
+
+/**
+ * Comment.
+ */
+
+a {
+  text-decoration: none;
+}
+
+a:hover,
+a.pseudo-class-hover {
+  text-decoration: underline;
+}
+
+a:active,
+a.pseudo-class-active {
+  font-weight: bold;
+}
+
+a:hover,
+a:focus,
+a.pseudo-class-hover,
+a.pseudo-class-focus {
+  font-weight: bold;
+}
+
+a.lol:active,
+a.lol.pseudo-class-active {
+  font-weight: normal;
+}
+
+a:nth-child(5),
+a.pseudo-class-nth-child\(5\) {
+  border: 1px solid papayawhip;
+}
+
+a:hover:focus,
+a.pseudo-class-hover.pseudo-class-focus {
+  font-weight: bold;
+}
+
+a:before {
+  color: white;
+}
+
+a::before {
+  color: white;
+}
+
+a:before,
+a::before {
+  color: white;
+}
+
+a:hover::before,
+a.pseudo-class-hover::before {
+  border-top-color: blue;
+}
+
+a:active:focus:hover::before,
+a.pseudo-class-active.pseudo-class-focus.pseudo-class-hover::before {
+  border-bottom-color: blue;
+}
+
+a:active:focus + div:hover,
+a.pseudo-class-active.pseudo-class-focus + div.pseudo-class-hover {
+  color: magenta;
+}

--- a/test/fixtures/whitelist-pseudos.out.css
+++ b/test/fixtures/whitelist-pseudos.out.css
@@ -1,0 +1,67 @@
+
+/**
+ * Comment.
+ */
+
+a {
+  text-decoration: none;
+}
+
+a:hover,
+a.\:hover {
+  text-decoration: underline;
+}
+
+a:active,
+a.\:active {
+  font-weight: bold;
+}
+
+a:hover,
+a:focus,
+a.\:hover,
+a.\:focus {
+  font-weight: bold;
+}
+
+a.lol:active,
+a.lol.\:active {
+  font-weight: normal;
+}
+
+a:nth-child(5) {
+  border: 1px solid papayawhip;
+}
+
+a:hover:focus,
+a.\:hover.\:focus {
+  font-weight: bold;
+}
+
+a:before {
+  color: white;
+}
+
+a::before {
+  color: white;
+}
+
+a:before,
+a::before {
+  color: white;
+}
+
+a:hover::before,
+a.\:hover::before {
+  border-top-color: blue;
+}
+
+a:active:focus:hover::before,
+a.\:active.\:focus.\:hover::before {
+  border-bottom-color: blue;
+}
+
+a:active:focus + div:hover,
+a.\:active.\:focus + div.\:hover {
+  color: magenta;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -38,3 +38,26 @@ test('split `rule.selector`', t => {
 
   return run(t, selectors, selectors, { });
 });
+
+
+test('optional prefixes', t => {
+
+  const expectedOut = read(
+    './fixtures/prefix-pseudos.out.css',
+    'utf-8'
+  );
+
+  return run(t, inCSS, expectedOut, { prefix: 'pseudo-class-' });
+});
+
+
+test('whitelist', t => {
+
+  const expectedOut = read(
+    './fixtures/whitelist-pseudos.out.css',
+    'utf-8'
+  );
+
+  return run(t, inCSS, expectedOut,
+    { psuedoClassWhitelist: ['hover', 'active', 'focus'] });
+});


### PR DESCRIPTION
I have added to configuration parameters to the project so that alternate prefixes can be used. This is so that the plugin can be used with our kss based style guide - but could be useful for others too.

I have also added a whitelist for pseudo classes so that only the wanted classes are converted.

I have added tests for both new options.
