### PR TITLE
Clean up .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,3 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-
-[*.{json,yml}]
-indent_size = 2


### PR DESCRIPTION
We do not need extra section with the same `indent_size`.