### PR TITLE
Add new CSS selectors to blacklist

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,22 @@ var plugin = function (options) {
   var blacklist = {
     ':root': true,
     ':host': true,
-    ':host-context': true
+    ':host-context': true,
+    ':where': true,
+    ':is': true,
+    ':not': true,
+    ':has': true,
+    ':nth-child': true,
+    ':nth-last-child': true,
+    ':nth-of-type': true,
+    ':nth-last-of-type': true,
+    ':first-child': true,
+    ':last-child': true,
+    ':first-of-type': true,
+    ':last-of-type': true,
+    ':only-child': true,
+    ':only-of-type': true,
+    ':empty': true
   };
 
   var prefix = options.prefix || '\\:';


### PR DESCRIPTION
Should we go to allow-list of only [user action pseudo-classes](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes#user_action_pseudo-classes) with an option to add more?