### PR TITLE
Always use restrictTo

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,8 @@
 {
   "extends": "eslint:recommended",
+  "parserOptions": {
+    "ecmaVersion": 2020
+  },
   "env": {
     "node": true
   }

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ $ npm install postcss-pseudo-classes
 ## Options
 
 ```js
-<<<<<<< HEAD
 require('postcss-pseudo-classes')({
   // (optional) list of pseudo-classes to process. Can be an array or
   // a function receiving default list and returning new one.

--- a/README.md
+++ b/README.md
@@ -38,14 +38,13 @@ $ npm install postcss-pseudo-classes
 ## Options
 
 ```js
+<<<<<<< HEAD
 require('postcss-pseudo-classes')({
-  // default contains `:root`.
-  blacklist: [],
-
-  // (optional) create classes for a restricted list of selectors
-  // N.B. the colon (:). By default it uses all
-  // interactive pseudo-classes.
-  restrictTo: [':nth-child', 'hover'],
+  // (optional) list of pseudo-classes to process. Can be an array or
+  // a function receiving default list and returning new one.
+  custom: [
+    ':hover', ':active', ':focus', ':visited', ':focus-visible', ':focus-within'
+  ],
 
   // default is `false`. If `true`, will output CSS
   // with all combinations of pseudo styles/pseudo classes.
@@ -53,7 +52,7 @@ require('postcss-pseudo-classes')({
 
   // default is `true`. If `false`, will generate
   // pseudo classes for `:before` and `:after`
-  preserveBeforeAfter: false
+  preserveBeforeAfter: false,
 
   // default is `\:`. It will be added to pseudo classes.
   prefix: '\\:'
@@ -62,8 +61,7 @@ require('postcss-pseudo-classes')({
 
 ## Edge cases
 
-* This plugin escapes parenthesis so `:nth-child(5)` would look like `.class.\:nth-child\(5\)` and can be used as a regular class: `<button class=":nth-child(5)">howdy</button>`.
-* Pseudo-selectors with two colons are ignored entirely since they're a slightly different thing.
+* The plugin process only [user-action pseudo-classes](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes#user_action_pseudo-classes).
 * Chained pseudo-selectors just become chained classes: `:focus:hover` becomes `.\:focus.\:hover`.
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ require('postcss-pseudo-classes')({
 
 ## Edge cases
 
-* The plugin process only [user-action pseudo-classes](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes#user_action_pseudo-classes).
+* The plugin processes only [user-action pseudo-classes](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes#user_action_pseudo-classes).
 * Chained pseudo-selectors just become chained classes: `:focus:hover` becomes `.\:focus.\:hover`.
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ require('postcss-pseudo-classes')({
   blacklist: [],
 
   // (optional) create classes for a restricted list of selectors
-  // N.B. the colon (:) is optional
+  // N.B. the colon (:). By default it uses all
+  // interactive pseudo-classes.
   restrictTo: [':nth-child', 'hover'],
 
   // default is `false`. If `true`, will output CSS

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ $ npm install postcss-pseudo-classes
 ```js
 require('postcss-pseudo-classes')({
   // (optional) list of pseudo-classes to process. Can be an array or
-  // a function receiving default list and returning new one.
+  // a function receiving the default list of pseudo-classes and returning new one.
   custom: [
     ':hover', ':active', ':focus', ':visited', ':focus-visible', ':focus-within'
   ],

--- a/index.js
+++ b/index.js
@@ -1,3 +1,12 @@
+var interactiveStates = {
+  ':hover': true,
+  ':active': true,
+  ':focus': true,
+  ':visited': true,
+  ':focus-visible': true,
+  ':focus-within': true
+};
+
 var plugin = function (options) {
   options = options || {};
   options.preserveBeforeAfter = options.preserveBeforeAfter || true;
@@ -27,6 +36,8 @@ var plugin = function (options) {
       }
       return target;
     }, {});
+  } else {
+    restrictTo = interactiveStates;
   }
 
   return {

--- a/index.js
+++ b/index.js
@@ -20,20 +20,19 @@ var plugin = function (options) {
 
   var prefix = options.prefix || '\\:';
 
-  (options.blacklist || []).forEach(function (blacklistItem) {
-    blacklist[blacklistItem] = true;
-  });
-
   var restrictTo;
-
-  if (Array.isArray(options.restrictTo) && options.restrictTo.length) {
-    restrictTo = options.restrictTo.reduce(function (target, pseudoClass) {
+  if (options.custom) {
+    var list;
+    if (Array.isArray(options.custom)) {
+      list = options.custom;
+    } else {
+      list = options.custom(Object.keys(interactiveStates));
+    }
+    restrictTo = list.reduce(function (target, pseudoClass) {
       var finalClass =
         (pseudoClass.charAt(0) === ':' ? '' : ':') +
         pseudoClass.replace(/\(.*/g, '');
-      if (!Object.prototype.hasOwnProperty.call(target, finalClass)) {
-        target[finalClass] = true;
-      }
+      target[finalClass] = true;
       return target;
     }, {});
   } else {
@@ -86,10 +85,7 @@ var plugin = function (options) {
               var classPseudos = pseudos.map(function (pseudo) {
                 var pseudoToCheck = pseudo.replace(/\(.*/g, '');
                 // restrictTo a subset of pseudo classes
-                if (
-                  blacklist[pseudoToCheck] ||
-                  (restrictTo && !restrictTo[pseudoToCheck])
-                ) {
+                if (!restrictTo[pseudoToCheck]) {
                   return pseudo;
                 }
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var interactiveStates = {
+const INTERACTIVE_STATES = {
   ':hover': true,
   ':active': true,
   ':focus': true,
@@ -7,52 +7,51 @@ var interactiveStates = {
   ':focus-within': true
 };
 
-var plugin = function (options) {
-  options = options || {};
-  options.preserveBeforeAfter = options.preserveBeforeAfter || true;
+const plugin = function (options = {}) {
+  options.preserveBeforeAfter = options.preserveBeforeAfter ?? true;
 
   // Backwards compatibility--we always by default ignored `:root`.
-  var blacklist = {
+  const blacklist = {
     ':root': true,
     ':host': true,
     ':host-context': true
   };
 
-  var prefix = options.prefix || '\\:';
+  const prefix = options.prefix ?? '\\:';
 
-  var restrictTo;
+  let restrictTo;
   if (options.custom) {
-    var list;
+    let list;
     if (Array.isArray(options.custom)) {
       list = options.custom;
     } else {
-      list = options.custom(Object.keys(interactiveStates));
+      list = options.custom(Object.keys(INTERACTIVE_STATES));
     }
-    restrictTo = list.reduce(function (target, pseudoClass) {
-      var finalClass =
+    restrictTo = list.reduce((target, pseudoClass) => {
+      const finalClass =
         (pseudoClass.charAt(0) === ':' ? '' : ':') +
         pseudoClass.replace(/\(.*/g, '');
       target[finalClass] = true;
       return target;
     }, {});
   } else {
-    restrictTo = interactiveStates;
+    restrictTo = INTERACTIVE_STATES;
   }
 
   return {
     postcssPlugin: 'postcss-pseudo-classes',
-    prepare: function () {
-      var fixed = [];
+    prepare() {
+      const fixed = [];
       return {
-        Rule: function (rule) {
+        Rule(rule) {
           if (fixed.indexOf(rule) !== -1) {
             return;
           }
           fixed.push(rule);
 
-          var combinations;
+          let combinations;
 
-          rule.selectors.forEach(function (selector) {
+          rule.selectors.forEach(selector => {
             // Ignore some popular things that are never useful
             if (blacklist[selector]) {
               return;
@@ -62,11 +61,11 @@ var plugin = function (options) {
               return;
             }
 
-            var selectorParts = selector.split(' ');
-            var pseudoedSelectorParts = [];
+            const selectorParts = selector.split(' ');
+            const pseudoedSelectorParts = [];
 
-            selectorParts.forEach(function (selectorPart, index) {
-              var pseudos = selectorPart.match(/::?([^:]+)/g);
+            selectorParts.forEach((selectorPart, index) => {
+              const pseudos = selectorPart.match(/::?([^:]+)/g);
 
               if (!pseudos) {
                 if (options.allCombinations) {
@@ -77,13 +76,13 @@ var plugin = function (options) {
                 return;
               }
 
-              var baseSelector = selectorPart.substr(
+              const baseSelector = selectorPart.substr(
                 0,
                 selectorPart.length - pseudos.join('').length
               );
 
-              var classPseudos = pseudos.map(function (pseudo) {
-                var pseudoToCheck = pseudo.replace(/\(.*/g, '');
+              const classPseudos = pseudos.map(pseudo => {
+                const pseudoToCheck = pseudo.replace(/\(.*/g, '');
                 // restrictTo a subset of pseudo classes
                 if (!restrictTo[pseudoToCheck]) {
                   return pseudo;
@@ -118,7 +117,7 @@ var plugin = function (options) {
                 combinations = createCombinations(pseudos, classPseudos);
                 pseudoedSelectorParts[index] = [];
 
-                combinations.forEach(function (combination) {
+                combinations.forEach(combination => {
                   pseudoedSelectorParts[index].push(baseSelector + combination);
                 });
               } else {
@@ -129,12 +128,12 @@ var plugin = function (options) {
             });
 
             if (options.allCombinations) {
-              var serialCombinations = createSerialCombinations(
+              const serialCombinations = createSerialCombinations(
                 pseudoedSelectorParts,
                 appendWithSpace
               );
 
-              serialCombinations.forEach(function (combination) {
+              serialCombinations.forEach(combination => {
                 addSelector(combination);
               });
             } else {
@@ -156,11 +155,11 @@ plugin.postcss = true;
 
 // a.length === b.length
 function createCombinations(a, b) {
-  var combinations = [''];
-  var newCombinations;
-  for (var i = 0, len = a.length; i < len; i += 1) {
+  let combinations = [''];
+  let newCombinations;
+  for (let i = 0, len = a.length; i < len; i += 1) {
     newCombinations = [];
-    combinations.forEach(function (combination) {
+    combinations.forEach(combination => {
       newCombinations.push(combination + a[i]);
       // Don't repeat work.
       if (a[i] !== b[i]) {
@@ -174,12 +173,12 @@ function createCombinations(a, b) {
 
 // arr = [[list of 1st el], [list of 2nd el] ... etc]
 function createSerialCombinations(arr, fn) {
-  var combinations = [''];
-  var newCombinations;
-  arr.forEach(function (elements) {
+  let combinations = [''];
+  let newCombinations;
+  arr.forEach(elements => {
     newCombinations = [];
-    elements.forEach(function (element) {
-      combinations.forEach(function (combination) {
+    elements.forEach(element => {
+      combinations.forEach(combination => {
         newCombinations.push(fn(combination, element));
       });
     });

--- a/test/fixtures/prefix.out.css
+++ b/test/fixtures/prefix.out.css
@@ -29,8 +29,7 @@ a.lol.pseudo-class-active {
   font-weight: normal;
 }
 
-a:nth-child(5),
-a.pseudo-class-nth-child\(5\) {
+a:nth-child(5) {
   border: 1px solid papayawhip;
 }
 

--- a/test/fixtures/pseudos-combinations.out.css
+++ b/test/fixtures/pseudos-combinations.out.css
@@ -29,8 +29,7 @@ a.lol.\:active {
   font-weight: normal;
 }
 
-a:nth-child(5),
-a.\:nth-child\(5\) {
+a:nth-child(5) {
   border: 1px solid papayawhip;
 }
 

--- a/test/fixtures/pseudos.out.css
+++ b/test/fixtures/pseudos.out.css
@@ -29,8 +29,7 @@ a.lol.\:active {
   font-weight: normal;
 }
 
-a:nth-child(5),
-a.\:nth-child\(5\) {
+a:nth-child(5) {
   border: 1px solid papayawhip;
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -36,8 +36,22 @@ test(
 test('should add pseudoclass selectors from a list and ignore the rest', t => {
   const input = read('./fixtures/pseudos-restricted.css');
   const expectedOut = read('./fixtures/pseudos-restricted.out.css');
-  const restrictTo = ['nth-child', ':hover', 'active'];
-  return run(t, input, expectedOut, { allCombinations: true, restrictTo });
+  return run(t, input, expectedOut, {
+    allCombinations: true,
+    custom: ['nth-child', ':hover', 'active']
+  });
+});
+
+test('should add pseudoclass selectors from a function', t => {
+  const input = read('./fixtures/pseudos-restricted.css');
+  const expectedOut = read('./fixtures/pseudos-restricted.out.css');
+  return run(t, input, expectedOut, {
+    allCombinations: true,
+    custom: list => {
+      t.truthy(list.includes(':focus'));
+      return ['nth-child', ':hover', 'active'];
+    }
+  });
 });
 
 test('should ignore pseudoclass selections in the blacklist', t => {


### PR DESCRIPTION
I suggest to always have allow-list of states, because right now we prefix `:where()`, `:not()` and many other CSS functions like this.

Even if we blacklist when, new will be added in the future. It is more likely to add new non-interactive pseudo-state.