### PR TITLE
Speed-up plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,10 @@ var plugin = function (options) {
               return;
             }
 
+            if (!selector.includes(':')) {
+              return;
+            }
+
             var selectorParts = selector.split(' ');
             var pseudoedSelectorParts = [];
 


### PR DESCRIPTION
The popular hack to make a quick-test and avoid more expensive RegExp for the cases where we have more negative results, than positive.