### PR TITLE
Clean up docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PostCSS Pseudo Classes [![Build Status][ci-img]][ci]
+# PostCSS Pseudo Classes
 
 [PostCSS] plugin to automatically add in companion classes
 where pseudo-selectors are used.
@@ -6,9 +6,24 @@ This allows you to add the class name to force the styling of a pseudo-selector,
 which can be really helpful for testing or being able
 to concretely reach all style states.
 
+Example:
+
+```css
+.some-selector:hover {
+  text-decoration: underline;
+}
+```
+
+yields
+
+```css
+.some-selector:hover,
+.some-selector.\:hover {
+  text-decoration: underline;
+}
+```
+
 [PostCSS]: https://github.com/postcss/postcss
-[ci-img]:  https://travis-ci.org/giuseppeg/postcss-pseudo-classes.svg
-[ci]:      https://travis-ci.org/giuseppeg/postcss-pseudo-classes
 
 ### Credits
 
@@ -20,10 +35,10 @@ This plugin is a port of [rework-pseudo-classes](https://github.com/SlexAxton/re
 $ npm install postcss-pseudo-classes
 ```
 
-## Example
+## Options
 
 ```js
-var pseudoclasses = require('postcss-pseudo-classes')({
+require('postcss-pseudo-classes')({
   // default contains `:root`.
   blacklist: [],
 
@@ -42,33 +57,6 @@ var pseudoclasses = require('postcss-pseudo-classes')({
   // default is `\:`. It will be added to pseudo classes.
   prefix: '\\:'
 });
-
-postcss([ pseudoclasses ])
-  .process(css)
-  .then(function (result) { console.log(result.css); });
-```
-
-### style.css
-
-```css
-.some-selector:hover {
-  text-decoration: underline;
-}
-```
-
-yields
-
-```css
-.some-selector:hover,
-.some-selector.\:hover {
-  text-decoration: underline;
-}
-```
-
-### usage
-
-```html
-<button class="some-selector :hover">howdy</button>
 ```
 
 ## Edge cases


### PR DESCRIPTION
1. We moved to another CI, so we don’t need those badges. I don’t think we should add new one, since they are not very useful for users and reduce page performance.
2. I moved CSS example on top because it is the best way to explain the plugin.
3. I removed PostCSS JS API example (and renamed section to Options) because only a few people use direct JS API (most of the people use Vite/webpack).
4. I removed HTML example because it is not very clear.