### PR TITLE
ignore :is pseudoclass as parentheses can contain unhandled spaces and further pseudoclasses

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ var plugin = function (options) {
   var blacklist = {
     ':root': true,
     ':host': true,
-    ':host-context': true
+    ':host-context': true,
+    ':is': true
   };
 
   var prefix = options.prefix || '\\:';

--- a/test/fixtures/prefix.out.css
+++ b/test/fixtures/prefix.out.css
@@ -66,3 +66,8 @@ a:active:focus + div:hover,
 a.pseudo-class-active.pseudo-class-focus + div.pseudo-class-hover {
   color: magenta;
 }
+
+a:is(:hover, .current),
+a:is(.pseudo-class-hover, .current) {
+  color: firebrick;
+}

--- a/test/fixtures/pseudos-combinations.out.css
+++ b/test/fixtures/pseudos-combinations.out.css
@@ -80,3 +80,8 @@ a.\:active:focus + div.\:hover,
 a.\:active.\:focus + div.\:hover {
   color: magenta;
 }
+
+a:is(:hover, .current),
+a:is(.\:hover, .current) {
+  color: firebrick;
+}

--- a/test/fixtures/pseudos.css
+++ b/test/fixtures/pseudos.css
@@ -56,3 +56,7 @@ a:active:focus:hover::before {
 a:active:focus + div:hover {
   color: magenta;
 }
+
+a:is(:hover, .current) {
+  color: firebrick;
+}

--- a/test/fixtures/pseudos.out.css
+++ b/test/fixtures/pseudos.out.css
@@ -66,3 +66,8 @@ a:active:focus + div:hover,
 a.\:active.\:focus + div.\:hover {
   color: magenta;
 }
+
+a:is(:hover, .current),
+a:is(.\:hover, .current) {
+  color: firebrick;
+}


### PR DESCRIPTION
 - when `:is` was escaped, the space within the brackets was not escaped and we got a unusable class of `a\:is\(.\:hover, .current)`, which also has an unescaped closing bracket
 - IMO without `allCombinations` it's reasonable to expect the `:is` to be maintained as-is, so that explicit `.\:hover` classes can be programmatically added without having to add classes for each of the `:is` rules in the stylesheet, which is likely to be non-trivial given how this pseudoclass is used in the wild.

I've solved in this PR by blacklisting `:is`, but possibly there is a better solution out there which IMO would need to replicate some of the effect of `allCombinations` even in the absence of that option.

Example ideal solution, not implemented in this PR:
```
    a:is(:hover, .current, .\:hover),
    a.\:is\(\:hover\,\ \.current\) {
      color: firebrick;
    }
```
Above demonstrates recursive addition of new class within the 'sub selector' of the :is parenthesis, as well as proper escaping of a full :is statement (which I can't imagine anyone ever using)